### PR TITLE
Added implicit promotions for addition and corresponding tests

### DIFF
--- a/pochivm/api_base.h
+++ b/pochivm/api_base.h
@@ -117,11 +117,23 @@ Value<T>::operator Value<U>() const
 
 // Arithmetic ops convenience operator overloading
 //
-template<typename T, typename = std::enable_if_t<
-             AstTypeHelper::primitive_type_supports_binary_op<T, AstTypeHelper::BinaryOps::ADD>::value> >
-Value<T> operator+(const Value<T>& lhs, const Value<T>& rhs)
+template <typename T, typename U,
+          typename = std::enable_if_t<AstTypeHelper::primitive_type_supports_binary_op<U, AstTypeHelper::BinaryOps::ADD>::value>,
+          typename = std::enable_if_t<AstTypeHelper::primitive_type_supports_binary_op<T, AstTypeHelper::BinaryOps::ADD>::value> >
+Value<typename std::common_type<T, U>::type> operator+(const Value<T> &lhs, const Value<U> &rhs)
 {
-    return Value<T>(new AstArithmeticExpr(AstArithmeticExprType::ADD, lhs.__pochivm_value_ptr, rhs.__pochivm_value_ptr));
+    using return_type = typename std::common_type<T, U>::type;
+    static_assert(std::is_signed<T>::value == std::is_signed<U>::value ||
+                      std::is_floating_point<return_type>::value,
+                  "cannot add two values of different signedness");
+    if(!std::is_same<T, return_type>::value)
+        return Value<return_type>(new AstArithmeticExpr(AstArithmeticExprType::ADD,
+                                                        StaticCast<return_type>(lhs).__pochivm_value_ptr, rhs.__pochivm_value_ptr));
+    if(!std::is_same<U, return_type>::value)
+        return Value<return_type>(new AstArithmeticExpr(AstArithmeticExprType::ADD,
+                                                        lhs.__pochivm_value_ptr, StaticCast<return_type>(rhs).__pochivm_value_ptr));
+    return Value<return_type>(new AstArithmeticExpr(AstArithmeticExprType::ADD,
+                                                    lhs.__pochivm_value_ptr, rhs.__pochivm_value_ptr));
 }
 
 template<typename T, typename = std::enable_if_t<

--- a/test_sanity_arith_expr.cpp
+++ b/test_sanity_arith_expr.cpp
@@ -146,6 +146,147 @@ void TestInterestingIntegerParams(std::function<std::function<void(T, T)>()> fnG
     }
 }
 
+template<typename T, typename U>
+void AdditionWithDifferentTypesHelper(T lhs, U rhs)
+{
+    AutoThreadPochiVMContext apv;
+    AutoThreadErrorContext arc;
+    AutoThreadLLVMCodegenContext alc;
+    NewModule("test");
+    using FnPrototype = decltype(lhs + rhs) (*)(T, U);
+    auto [fn, a, b] = NewFunction<FnPrototype>("MyFn");
+    fn.SetBody(
+        Return(a + b)
+    );
+    ReleaseAssert(thread_pochiVMContext->m_curModule->Validate());
+    thread_pochiVMContext->m_curModule->PrepareForDebugInterp();
+    thread_pochiVMContext->m_curModule->PrepareForFastInterp();
+    auto interpFn = thread_pochiVMContext->m_curModule->
+                           GetDebugInterpGeneratedFunction<FnPrototype>("MyFn");
+    ReleaseAssert(interpFn);
+    auto fastinterpFn = thread_pochiVMContext->m_curModule->
+                           GetFastInterpGeneratedFunction<FnPrototype>("MyFn");
+    ReleaseAssert(fastinterpFn);                                                 
+    thread_pochiVMContext->m_curModule->EmitIR();
+    thread_pochiVMContext->m_curModule->OptimizeIRIfNotDebugMode(2 /*optLevel*/);
+    SimpleJIT jit;
+    jit.SetModule(thread_pochiVMContext->m_curModule);
+    FnPrototype jitFn = jit.GetFunction<FnPrototype>("MyFn");
+    std::vector<decltype(jitFn(lhs, rhs))> answers = {jitFn(lhs, rhs), interpFn(lhs, rhs), fastinterpFn(lhs, rhs)};
+
+    // Ignore warnings about implicit float/double conversions/promotions
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+    #pragma clang diagnostic ignored "-Wdouble-promotion"
+
+    auto expected = lhs + rhs;
+
+    #pragma clang diagnostic pop
+
+    ReleaseAssert(typeid(answers[0]) == typeid(expected));
+    for(auto answer : answers)
+        CompareResults(static_cast<decltype(lhs + rhs)>(lhs),
+                    static_cast<decltype(lhs + rhs)>(rhs), answer, expected);
+}
+
+template <typename T, typename U>
+void TestAdditionWithDifferentTypes(T v1, U v2) {
+    AdditionWithDifferentTypesHelper(v1, v2);
+    AdditionWithDifferentTypesHelper(v2, v1);
+}
+
+#define FOR_EACH_PARAMS(a, b, c, d) \
+F(a, a) \
+F(a, b) \
+F(a, c) \
+F(a, d) \
+F(b, b) \
+F(b, c) \
+F(b, d) \
+F(c, c) \
+F(c, d) \
+F(d, d)
+
+void TestAdditionSignedWithPromotion() {
+    int32_t pos_32 = 15;
+    int32_t neg_32 = -15;
+    int64_t pos_64 = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+    int64_t neg_64 = static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1;
+    #define F(v1, v2) TestAdditionWithDifferentTypes(v1, v2);
+    FOR_EACH_PARAMS(pos_32, neg_32, pos_64, neg_64)
+    #undef F
+    int32_t max_32 = std::numeric_limits<int32_t>::max();
+    int32_t min_32 = std::numeric_limits<int32_t>::min();
+
+    TestAdditionWithDifferentTypes(max_32, pos_64);
+    TestAdditionWithDifferentTypes(max_32, neg_64);
+    TestAdditionWithDifferentTypes(min_32, pos_64);
+    TestAdditionWithDifferentTypes(min_32, neg_64);
+
+    float pos_float = static_cast<float>(1.234567);
+    float neg_float = static_cast<float>(-1.234567);
+    double pos_double = static_cast<double>(std::numeric_limits<float>::max()) + 3.03;
+    double neg_double = static_cast<double>(std::numeric_limits<float>::min()) - 3.03;
+    int64_t small_pos_64 = 15;
+    int64_t small_neg_64 = -15;
+
+    TestAdditionWithDifferentTypes(pos_float, pos_32);
+    TestAdditionWithDifferentTypes(pos_float, neg_32);
+    TestAdditionWithDifferentTypes(pos_float, small_pos_64);
+    TestAdditionWithDifferentTypes(pos_float, small_neg_64);
+    TestAdditionWithDifferentTypes(pos_double, pos_32);
+    TestAdditionWithDifferentTypes(pos_double, neg_32);
+    TestAdditionWithDifferentTypes(pos_double, max_32);
+    TestAdditionWithDifferentTypes(pos_double, min_32);
+    TestAdditionWithDifferentTypes(pos_double, small_pos_64);
+    TestAdditionWithDifferentTypes(pos_double, small_neg_64);
+    TestAdditionWithDifferentTypes(pos_double, pos_64);
+    TestAdditionWithDifferentTypes(pos_double, neg_64);
+
+    TestAdditionWithDifferentTypes(pos_double, pos_float);
+    TestAdditionWithDifferentTypes(pos_double, neg_float);
+    TestAdditionWithDifferentTypes(neg_double, pos_float);
+    TestAdditionWithDifferentTypes(neg_double, neg_float);
+
+    TestAdditionWithDifferentTypes(neg_float, pos_32);
+    TestAdditionWithDifferentTypes(neg_float, neg_32);
+    TestAdditionWithDifferentTypes(neg_float, small_pos_64);
+    TestAdditionWithDifferentTypes(neg_float, small_neg_64);
+    TestAdditionWithDifferentTypes(neg_double, pos_32);
+    TestAdditionWithDifferentTypes(neg_double, neg_32);
+    TestAdditionWithDifferentTypes(neg_double, max_32);
+    TestAdditionWithDifferentTypes(neg_double, min_32);
+    TestAdditionWithDifferentTypes(neg_double, small_pos_64);
+    TestAdditionWithDifferentTypes(neg_double, small_neg_64);
+    TestAdditionWithDifferentTypes(neg_double, pos_64);
+    TestAdditionWithDifferentTypes(neg_double, neg_64);
+}
+
+void TestAdditionUnsignedWithPromotion() {
+    uint32_t pos_32 = 15;
+    uint32_t max_32 = std::numeric_limits<uint32_t>::max();
+    uint64_t pos_64 = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;
+    uint64_t max_64 = std::numeric_limits<uint64_t>::max();
+    #define F(v1, v2) TestAdditionWithDifferentTypes(v1, v2);
+    FOR_EACH_PARAMS(pos_32, max_32, pos_64, max_64)
+    #undef F
+    uint64_t small_pos_64 = 15;
+    float pos_float = static_cast<float>(1.234567);
+    double pos_double = static_cast<double>(std::numeric_limits<float>::max()) + static_cast<double>(3.03);
+
+    TestAdditionWithDifferentTypes(pos_float, pos_32);
+    TestAdditionWithDifferentTypes(pos_float, small_pos_64);
+    TestAdditionWithDifferentTypes(pos_float, pos_double);
+    TestAdditionWithDifferentTypes(pos_double, pos_32);
+    TestAdditionWithDifferentTypes(pos_double, max_32);
+    TestAdditionWithDifferentTypes(pos_double, small_pos_64);
+}
+
+void TestAdditionWithPromotion() {
+    TestAdditionSignedWithPromotion();
+    TestAdditionUnsignedWithPromotion();
+}
+
 template<typename T>
 void TestInterestingFloatParams(std::function<std::function<void(T, T)>()> fnGen, bool isDivOp)
 {
@@ -287,4 +428,6 @@ TEST(Sanity, ArithAndCompareExpr)
     //
     TestBoolParams(GetEqFn<bool>);
     TestBoolParams(GetNEqFn<bool>);
+
+    TestAdditionWithPromotion();
 }


### PR DESCRIPTION
Change Pochi addition semantics to implicitly convert integers/floats/doubles when adding different types. Doesn't work for 8 bit and 16 bit values.

I'm not sure if I should refactor the tests so that they are easier to reuse if we were to ever add implicit conversion to other operations or if we're planning on doing that in the near future.  