### PR TITLE
Fix typos in "Build and Run Unit Test" doc page

### DIFF
--- a/sphinx/build_and_test.rst
+++ b/sphinx/build_and_test.rst
@@ -18,7 +18,7 @@ Clone the repository::
   git clone https://github.com/sillycross/PochiVM PochiVM
   cd PochiVM
   
-The build script is a Python script named ``pochivm_build``. 
+The build script is a Python script named ``pochivm-build``. 
 There are 3 possible build flavors: ``debug``, ``release`` and ``production``.
 The debug and release builds are testing builds with assertions enabled, 
 while ``production`` is intended for production use, with full optimizations enabled
@@ -26,8 +26,8 @@ and all assertions disabled.
 
 To get a ``debug`` build, run::
 
-  python3 pochivm_build cmake debug
-  python3 pochivm_build make debug
+  python3 pochivm-build cmake debug
+  python3 pochivm-build make debug
 
 The built artifact is located in ``./build/[flavor]/main``, it is the Testing Suite for PochiVM. 
 The built artifact is also copied to the project root by the build script.
@@ -37,9 +37,9 @@ Run the built artifact::
 
 It should finish in a few seconds with no test failures. If not, please report a bug.
 
-To get a release or production build, just change the parameter passed to ``pochivm_build``.
-As is all cmake projects, the ``camke`` command is usually only needed for the first time you build the project. 
-Later only running ``python3 pochivm_build make [flavor]`` should be enough.
+To get a release or production build, just change the parameter passed to ``pochivm-build``.
+As is all cmake projects, the ``cmake`` command is usually only needed for the first time you build the project. 
+Later only running ``python3 pochivm-build make [flavor]`` should be enough.
 
 .. note::
   


### PR DESCRIPTION
This PR fixes some typos in the [build instructions doc page](https://sillycross.github.io/PochiVM/build_and_test.html).